### PR TITLE
Arch: refactor types to associate Request and Response types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "schemars",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 schemars = "0.8.22"
+serde = "1.0.218"
 serde_json = "1.0.139"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "types": "index.d.ts",
   "scripts": {
-    "build": "cargo run | json2ts -o index.d.ts"
+    "build": "cargo run --bin api | json2ts -o index.d.ts"
   },
   "repository": {
     "type": "git",

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -1,0 +1,36 @@
+use api::{API, APICollection, AuthRequest, AuthResponse, User};
+use serde_json::to_string_pretty;
+
+fn login(req: AuthRequest) -> Result<AuthResponse, ()> {
+	Ok(AuthResponse {
+		user: User {
+			id: 1,
+			name: req.username,
+		},
+		token: "token".to_string(),
+	})
+}
+
+fn api_wrapper<Request, Response>(
+	api: impl Fn(Request) -> Result<Response, ()>,
+) -> impl Fn(API<Request, Response>) -> Result<API<Request, Response>, ()> {
+	move |param| match param {
+		API::Call(req) => Ok(API::Return(api(req)?)),
+		API::Return(_) => Err(()),
+	}
+}
+
+fn api_router(param: APICollection) -> Result<APICollection, ()> {
+	Ok(match param {
+		APICollection::Auth(param) => api::APICollection::Auth(api_wrapper(login)(param)?),
+	})
+}
+
+fn main() {
+	let req: AuthRequest = AuthRequest {
+		username: "username".to_string(),
+		password: "password".to_string(),
+	};
+	let resp: APICollection = api_router(APICollection::Auth(API::Call(req))).unwrap();
+	println!("{}", to_string_pretty(&resp).unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,32 @@
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-#[derive(JsonSchema)]
+#[derive(JsonSchema, Serialize, Deserialize)]
 pub struct User {
 	pub id: u64,
 	pub name: String,
 }
 
-#[derive(JsonSchema)]
-pub struct LoginRequest {
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct AuthRequest {
 	pub username: String,
 	pub password: String,
 }
 
-#[derive(JsonSchema)]
-pub struct LoginResponse {
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub struct AuthResponse {
 	pub user: User,
 	pub token: String,
 }
 
-#[derive(JsonSchema)]
-pub enum API {
-	LoginRequest(LoginRequest),
-	LoginResponse(LoginResponse),
+// use enum instead of trait to support JsonSchema and typescript
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub enum API<Request, Response> {
+	Call(Request),
+	Return(Response),
+}
+
+#[derive(JsonSchema, Serialize, Deserialize)]
+pub enum APICollection {
+	Auth(API<AuthRequest, AuthResponse>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use api::API;
+use api::APICollection;
 use schemars::schema_for;
 use serde_json::to_string_pretty;
 
 fn main() {
-  println!("{}", to_string_pretty(&schema_for!(API)).unwrap());
+  println!("{}", to_string_pretty(&schema_for!(APICollection)).unwrap());
 }


### PR DESCRIPTION
`APICollection`: enum of `API<Request, Response>`

`API<Request, Response>` work as both:

+ The structure of request/response data

+ A trait that can get Request and Response type

Considering the compatibility with typescript, it is implemented as a enum:

```rust
enum API<Request, Response> {
  Call(Request),
  Return(Response),	
}
```